### PR TITLE
write config to a random string, even if it is empty

### DIFF
--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -9,6 +9,10 @@ terraform {
       source  = "hashicorp/local"
       version = ">= 2.4"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5.1"
+    }
     # NOTE: this is only required for the examples
     # this is used by the aws_access and aws_server modules
     aws = {

--- a/examples/byob/versions.tf
+++ b/examples/byob/versions.tf
@@ -9,6 +9,10 @@ terraform {
       source  = "hashicorp/null"
       version = ">= 3.2"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5.1"
+    }
     github = {
       source  = "integrations/github"
       version = ">= 5.32"

--- a/main.tf
+++ b/main.tf
@@ -18,6 +18,10 @@ locals {
     "install.sh",
   ])
 }
+resource "random_string" "config_name" {
+  length  = 4
+  special = false
+}
 
 module "download" {
   # skip download if local_file_path is set
@@ -27,16 +31,13 @@ module "download" {
   files   = local.expected_files
 }
 
-# if a config content is provided (or changed), write it to a file
-# all *.yaml files in the file_path will be copied to the config directory and read alphabetically
 resource "null_resource" "write_config" {
-  count = (local.config_content != "" ? 1 : 0)
   triggers = {
     config_content = local.config_content,
   }
   provisioner "local-exec" {
     command = <<-EOT
-      echo "${local.config_content}" > "${local.file_path}/config.yaml"
+      echo "${local.config_content}" > "${local.file_path}/${random_string.config_name.result}.yaml"
     EOT
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -13,5 +13,9 @@ terraform {
       source  = "integrations/github"
       version = ">= 5.32"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5.1"
+    }
   }
 }


### PR DESCRIPTION
This fixes a dependency chain issue in Terraform and since the module now uses multi-file config by default we can just write a file with a random name and if the file has a config it will be picked up, if it doesn't, it will be ignored.